### PR TITLE
Add helm delete to ensure disks are deleted

### DIFF
--- a/.github/workflows/gke_delete_cluster.yml
+++ b/.github/workflows/gke_delete_cluster.yml
@@ -33,6 +33,18 @@ jobs:
         service_account_key: ${{ secrets.GKE_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
 
+    # Install helm
+    - name: Install Helm
+      run: |
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+    # Although deleting the cluster is enough for deleting all k8s resources,
+    # deleting the chart is needed for handling the cleanup process of some resources
+    # (eg: having the GCP storage class delete the persistent disk when the PVC is deleted)
+    - name: Delete chart
+      run: |
+        helm delete biock8sredis
+
     # Delete cluster
     - run: |-
         gcloud container clusters delete "$GKE_CLUSTER" --zone "$GKE_ZONE" --quiet

--- a/.github/workflows/gke_delete_cluster.yml
+++ b/.github/workflows/gke_delete_cluster.yml
@@ -38,6 +38,10 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
+    # Get the GKE credentials so we can delete chart in the cluster
+    - run: |-
+       gcloud container clusters get-credentials "$GKE_CLUSTER" --zone "$GKE_ZONE"
+
     # Although deleting the cluster is enough for deleting all k8s resources,
     # deleting the chart is needed for handling the cleanup process of some resources
     # (eg: having the GCP storage class delete the persistent disk when the PVC is deleted)

--- a/.github/workflows/gke_delete_cluster_devel.yaml
+++ b/.github/workflows/gke_delete_cluster_devel.yaml
@@ -33,6 +33,18 @@ jobs:
         service_account_key: ${{ secrets.GKE_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
 
+    # Install helm
+    - name: Install Helm
+      run: |
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+    # Although deleting the cluster is enough for deleting all k8s resources,
+    # deleting the chart is needed for handling the cleanup process of some resources
+    # (eg: having the GCP storage class delete the persistent disk when the PVC is deleted)
+    - name: Delete chart
+      run: |
+        helm delete biock8sredis
+
     # Delete cluster
     - run: |-
         gcloud container clusters delete "$GKE_CLUSTER" --zone "$GKE_ZONE" --quiet

--- a/.github/workflows/gke_delete_cluster_devel.yaml
+++ b/.github/workflows/gke_delete_cluster_devel.yaml
@@ -38,6 +38,10 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
+    # Get the GKE credentials so we can delete chart in the cluster
+    - run: |-
+       gcloud container clusters get-credentials "$GKE_CLUSTER" --zone "$GKE_ZONE"
+
     # Although deleting the cluster is enough for deleting all k8s resources,
     # deleting the chart is needed for handling the cleanup process of some resources
     # (eg: having the GCP storage class delete the persistent disk when the PVC is deleted)


### PR DESCRIPTION
https://github.com/Bioconductor/BiocKubeInstall/pull/4 should make sure the PV created to fulfill the NFS PVC is set to have `Delete` as a `reclaimPolicy`, however this policy doesn't take effect unless the PVC (and subsequently bound PV) are deleted before the cluster itself.
In theory, the `helm delete` should cause the PVC to be explicitly deleted and hence propagate the reclaim policy to delete the bound PV and its fulfilling disk.

(This still needs testing in practice though)