### PR TITLE
better logs in manager pod and performance improvement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R:
       person("Martin", "Morgan", role = "aut"),
       person("Alex", "Mahmoud", role = "aut"),
       person("Jiefei", "Wang", role = "aut")
-	)
+     )
 Description: Build binaries for packages in R / Bioconductor using a
 	     Kubernetes Cluster. The package is internal to
 	     Bioconductor, and is used to create binaries for Docker
@@ -24,7 +24,6 @@ Depends: R (>= 4.0)
 Imports:
     BiocManager,
     AnVIL,
-    BiocParallel,
     RedisParam,
     BiocParallel,
     futile.logger,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Depends: R (>= 4.0)
 Imports:
     BiocManager,
     AnVIL,
+    BiocParallel,
     RedisParam,
     BiocParallel,
     futile.logger,

--- a/tests/testthat/test_depends_apply.R
+++ b/tests/testthat/test_depends_apply.R
@@ -1,41 +1,131 @@
 futile.logger::flog.threshold("FATAL", name = "kube_install")
+futile.logger::flog.threshold("FATAL", name = "kube_progress")
 
-test_that("'.depends_apply()' works", {
-
+test_that("reverse dependences", {
     deps <- list(
-        A = character(),
-        B = character(),
         C = "A",
         D = "B",
-        E = c("A", "B")
+        E = c("A", "B"),
+        F = "E",
+        G = NULL
     )
-    param <- BiocParallel::SerialParam()
-
-    noop <- setNames(list(), character())
-    result <- .depends_apply(noop, identity, BPPARAM = param)
-    expect_identical(setNames(logical(), character()), result)
-    
-    result <- .depends_apply(deps, identity, BPPARAM = param)
-    expect_true(all(result))
-
-    result <- .depends_apply(.exclude(deps, "A"), identity, BPPARAM = param)
-    expect_equal(
-        result,
-        c(B = TRUE, C = TRUE, D = TRUE, E = TRUE)
-    )
-
-    FUN <- function(x, ...)
-        if (x == "A") stop("oops")
-    result <- .depends_apply(deps, FUN, BPPARAM = param)
-    expect_equal(
-        result,
-        c(A = FALSE, B = TRUE, C = NA, D = TRUE, E = NA)
-    )
-
-    result <- .depends_apply(.exclude(deps, "B"), FUN, BPPARAM = param)
-    expect_equal(
-        result,
-        c(A = FALSE, C = NA, D = TRUE, E = NA)
-    )
-
+    rev_deps <- .reverse_deps(deps) 
+    expect_identical(rev_deps, 
+                     list(A = c("C", "E"), 
+                          B = c("D", "E"), 
+                          E = "F", 
+                          C = character(0), 
+                          D = character(0), 
+                          F = character(0),
+                          G = character(0))
+                     )
 })
+
+test_that("failure_propagation", {
+    deps <- list(
+        C = "A",
+        D = "B",
+        E = c("A", "B"),
+        F = "E",
+        G = NULL
+    )
+    rev_deps <- .reverse_deps(deps) 
+    
+    ## Fail a package which has "heavy" reverse dependances
+    failed <- new.env(parent = new.env())
+    affected <- .failure_propagation("A", failed, rev_deps)
+    expect_identical(affected, c("A", "C", "E", "F"))
+    expect_identical(sort(names(failed)), c("C", "E", "F"))
+    
+    ## The other package has already been failed.
+    affected <- .failure_propagation("E", failed, rev_deps)
+    expect_identical(affected, "E")
+    expect_identical(sort(names(failed)), c("C", "E", "F"))
+    
+    ## Fail a simple package
+    failed <- new.env(parent = new.env())
+    affected <- .failure_propagation("G", failed, rev_deps)
+    expect_identical(affected, c("G"))
+    expect_identical(sort(names(failed)), character(0))
+})
+
+
+test_that("package iterator", {
+    deps <- list(
+        C = "A",
+        D = "B",
+        E = c("A", "B"),
+        F = "E",
+        G = NULL
+    )
+    
+    myfun <- function(pkg, failed_list = c()){
+        if(pkg %in% failed_list){
+            simpleError("I failed")
+        }else{
+            ## check dependences
+            if (!all(deps[[pkg]] %in% success)) {
+                stop("Unsatisfied error")
+            }
+            success <<- c(success, pkg)
+            pkg
+        }
+    }
+    
+    params <- list(
+        SerialParam(),
+        SnowParam(2)
+    )
+    # p <- SerialParam()
+    for(p in params){
+        ## No failure
+        success <- c()
+        iter <- .dependency_graph_iterator_factory(
+            deps,
+            myfun
+        )
+        res <- bpiterate(
+            iter$ITER, iter$FUN,
+            REDUCE = iter$REDUCE,
+            init = c(), ## need to keep this as initial value for reducer
+            BPPARAM = SerialParam()
+        )
+        expect_identical(sort(names(res)), character(0))
+        expect_identical(length(success), 7L)
+        
+        ## Single failure
+        success <- c()
+        iter <- .dependency_graph_iterator_factory(
+            deps,
+            myfun
+        )
+        res <- bpiterate(
+            iter$ITER, iter$FUN,
+            failed_list = "F",
+            REDUCE = iter$REDUCE,
+            init = c(), ## need to keep this as initial value for reducer
+            BPPARAM = SerialParam()
+        )
+        expect_identical(sort(names(res)), "F")
+        expect_identical(length(success), 6L)
+        
+        ## Multiple failure
+        success <- c()
+        iter <- .dependency_graph_iterator_factory(
+            deps,
+            myfun
+        )
+        res <- bpiterate(
+            iter$ITER, iter$FUN,
+            failed_list = c("A", "B"),
+            REDUCE = iter$REDUCE,
+            init = c(), ## need to keep this as initial value for reducer
+            BPPARAM = SerialParam()
+        )
+        expect_identical(sort(names(res)), c("A", "B", "C", "D", "E", "F"))
+        expect_identical(length(success), 1L)
+    }
+})
+
+futile.logger::flog.threshold("INFO", name = "kube_install")
+futile.logger::flog.threshold("INFO", name = "kube_progress")

--- a/tests/testthat/test_kube_install.R
+++ b/tests/testthat/test_kube_install.R
@@ -1,36 +1,80 @@
 futile.logger::flog.threshold("FATAL", name = "kube_install")
+futile.logger::flog.threshold("FATAL", name = "kube_progress")
 
-test_that(".trim() works", {
-
+test_that("build dummy pkgs", {
     deps <- list(
-        A = list(),
-        B = list(),
-        C = list("A"),
-        D = list("B"),
-        E = list("A", "B")
+        C = "A",
+        D = "B",
+        E = c("A", "B"),
+        F = "E",
+        G = NULL
     )
-
-    lib <- tempfile()
-    bin <- tempfile()
-    param <- BiocParallel::SerialParam()
-
+    
+    lib_path <- tempdir()
+    bin_path <- tempdir()
+    logs_path<- tempdir()
+    
+    ## remove all files in the temp directory
+    do.call(file.remove, 
+            list(list.files(lib_path, full.names = TRUE, recursive = TRUE))
+    )
+    
+    param <- BiocParallel::SnowParam(2)
+    ## No error for all pkgs
     result <- with_mock(
-        kube_install_single_package = function(...) {},
-        kube_install(4L, lib, bin, deps, BPPARAM = param)
-    )
-    expect_equal(
-        result,
-        c(A = TRUE, B = TRUE, C = TRUE, D = TRUE, E = TRUE)
-    )
-
+                kube_install_single_package = function(...) {},
+                kube_install(lib_path, bin_path, logs_path, deps, 
+                             BPPARAM = param)
+            )
+    expect_identical(result, list())
+    
+    ## Build with single error
     result <- with_mock(
-        kube_install_single_package = function(x, ...) if (x %in% "A") stop(),
-        kube_install(4L, lib, bin, deps, BPPARAM = param)
+        kube_install_single_package = 
+            function(pkg, ...) if (pkg %in% "A") simpleError(pkg),
+        kube_install(lib_path, bin_path, logs_path, deps, 
+                     BPPARAM = param)
     )
-    expect_equal(
-        result,
-        c(A = FALSE, B = TRUE, C = NA, D = TRUE, E = NA)
+    expect_identical(sort(names(result)), c("A", "C", "E", "F"))
+    
+    ## Build with multiple errors
+    result <- with_mock(
+        kube_install_single_package = 
+            function(pkg, ...) if (pkg %in% c("A", "B")) simpleError(pkg),
+        kube_install(lib_path, bin_path, logs_path, deps, 
+                     BPPARAM = param)
     )
-
+    expect_identical(sort(names(result)), c("A", "B", "C", "D", "E", "F"))
 })
 
+
+test_that("build pkgs", {
+    deps0 <- c("agilp","AMOUNTAIN", "ASAFE", "BAC")
+    l <- rep(list(NULL), length(deps0))
+    names(l) <- deps0
+    
+    lib_path <- tempdir()
+    bin_path <- tempdir()
+    logs_path<- tempdir()
+    
+    ## remove all files in the temp directory
+    do.call(file.remove, 
+            list(list.files(lib_path, full.names = TRUE, recursive = TRUE))
+            )
+    
+    p <- BiocParallel::SnowParam(2)
+    res <- kube_install(lib_path, 
+                        bin_path,
+                        logs_path,
+                        l,
+                        p
+    )
+    
+    files <- list.files(lib_path, full.names = TRUE)
+    expect_equal(sum(grepl(".out$", files)), length(deps0))
+    ## 3 success + 1 final package 
+    expect_equal(sum(grepl(".gz$", files)), length(deps0))
+})
+
+futile.logger::flog.threshold("INFO", name = "kube_install")
+futile.logger::flog.threshold("INFO", name = "kube_progress")


### PR DESCRIPTION
The pull request contains:

1. Better logs in master(two streams: `kube_install` and `kube_progress`)
2. remove the packages from the task queue when the installation of their dependences failed
3. add unit tests for depends_apply and kube_install