### PR TITLE
Making persistence cloud-agnostic to run on Jetstream

### DIFF
--- a/.github/workflows/gke_run.yml
+++ b/.github/workflows/gke_run.yml
@@ -93,8 +93,8 @@ jobs:
           --timeout 600s \
           --set biocVersion="${DEVEL_MAJOR_VER}.${DEVEL_MINOR_VER}" \
           --set workers.image.tag="RELEASE_${DEVEL_MAJOR_VER}_${DEVEL_MINOR_VER}" \
-          --set volumeMountSize=$NFS_PD_SIZE \
-          --set gcpPdName="biockubeinstall-nfs-pd-${{needs.clusterlaunch.outputs.prefix}}-devel" inst/helm-chart --wait
+          --set persistence.size=$NFS_PD_SIZE \
+          --set persistence.gcpPdName="biockubeinstall-nfs-pd-${{needs.clusterlaunch.outputs.prefix}}-devel" inst/helm-chart --wait
 
     - name: check
       run: |
@@ -154,8 +154,8 @@ jobs:
           --timeout 600s \
           --set biocVersion="${RELEA_MAJOR_VER}.${RELEA_MINOR_VER}" \
           --set workers.image.tag="RELEASE_${RELEA_MAJOR_VER}_${RELEA_MINOR_VER}" \
-          --set volumeMountSize=$NFS_PD_SIZE \
-          --set gcpPdName="biockubeinstall-nfs-pd-${{needs.clusterlaunch.outputs.prefix}}-release" inst/helm-chart --wait
+          --set persistence.size=$NFS_PD_SIZE \
+          --set persistence.gcpPdName="biockubeinstall-nfs-pd-${{needs.clusterlaunch.outputs.prefix}}-release" inst/helm-chart --wait
 
     - name: check
       run: |

--- a/inst/helm-chart/templates/manager-deployment.yaml
+++ b/inst/helm-chart/templates/manager-deployment.yaml
@@ -12,8 +12,8 @@ spec:
       resources:
         {{- toYaml .Values.manager.resources | nindent 8 }}
       volumeMounts:
-        - name: {{ .Values.volumeMountName }}
-          mountPath: {{ .Values.volumeMountPath }}
+        - name: nfs-data
+          mountPath: {{ .Values.persistence.mountPath }}
         - name: service-key
           mountPath: /home/key.json
           subPath: {{ .Values.serviceKey }}
@@ -31,7 +31,7 @@ spec:
           Rscript -e 'BiocKubeInstall::kube_run("{{ .Values.biocVersion }}", image_name = "{{ .Values.dockerImageName }}", exclude_pkgs = c("canceR"))'
   restartPolicy: {{ .Values.restartPolicy | quote}}
   volumes:
-  - name: {{ .Values.volumeMountName }}
+  - name: nfs-data
     persistentVolumeClaim:
       claimName: {{.Release.Namespace}}-nfs
   - name: service-key

--- a/inst/helm-chart/templates/nfs-server-gke-pvc.yaml
+++ b/inst/helm-chart/templates/nfs-server-gke-pvc.yaml
@@ -5,12 +5,13 @@ metadata:
   labels:
     demo: nfs-pvc-provisioning
 spec:
-  storageClassName: manual
+  storageClassName: {{ .Values.persistence.storageClass }}
   accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:
-      storage: {{ .Values.volumeMountSize }}
+      storage: {{ .Values.persistence.size }}
 ---
+{{ if .Values.persistence.gcpPdName }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -18,14 +19,15 @@ metadata:
   labels:
     demo: nfs-pv-provisioning
 spec:
-  storageClassName: manual
+  storageClassName: {{ .Values.persistence.storageClass }}
   accessModes: [ "ReadWriteOnce" ]
   capacity:
-    storage: {{ .Values.volumeMountSize }}
+    storage: {{ .Values.persistence.size }}
   claimRef:
     namespace: {{ .Release.Namespace }}
     name: nfs-pvc-provisioning-demo
   gcePersistentDisk:
-    pdName: {{ .Values.gcpPdName }}
+    pdName: {{ .Values.persistence.gcpPdName }}
     fsType: ext4
 ---
+{{ end }}

--- a/inst/helm-chart/templates/worker-replicaset.yaml
+++ b/inst/helm-chart/templates/worker-replicaset.yaml
@@ -21,8 +21,8 @@ spec:
         resources:
           {{- toYaml .Values.workers.resources | nindent 10 }}
         volumeMounts:
-         - mountPath: {{ .Values.volumeMountPath }}
-           name: {{ .Values.volumeMountName }}
+         - mountPath: {{ .Values.persistence.mountPath }}
+           name: nfs-data
         command: ["sh"]
         args:
         - -c
@@ -31,6 +31,6 @@ spec:
           {{- end -}}
           R -f /home/docker/worker.R
       volumes:
-      - name: {{ .Values.volumeMountName }}
+      - name: nfs-data
         persistentVolumeClaim:
           claimName: {{.Release.Namespace}}-nfs

--- a/inst/helm-chart/values.yaml
+++ b/inst/helm-chart/values.yaml
@@ -39,13 +39,13 @@ manager:
       cpu: 1700m
 
 
-# Volume mount
-volumeMountName: bioc-nfs-mount
-volumeMountPath: /host
-volumeMountSize: 200Gi
+# Persistence settings for base NFS disk
+persistence:
+  mountPath: /host
+  size: 200Gi
+  storageClass: manual
+  #gcpPdName: manual-pd
 
-# GCP Pesristent Disk name
-gcpPdName: "manual-pd"
 
 # service key name
 serviceKey: bioc-binaries.json


### PR DESCRIPTION
- Consolidated `persistence` settings
- Removed `volumeMountName` (since it's internal to the template, hardcoding volume name is standard practice. It's the PVC name that matters)
- `volumeMountPath` --> `persistence.mountPath`
- `volumeMountSize` --> `persistence.size`
- `gcpPdName` --> `persistence.gcpPdName`
- New value: `persistence.storageClass`

For Jetstream Rancher cluster, run with `--set persistence.storageClass=ebs`