### PR TITLE
Make builds run on Monday.

### DIFF
--- a/.github/workflows/gke_run.yml
+++ b/.github/workflows/gke_run.yml
@@ -4,7 +4,7 @@ name: Start GKE cluster and build devel then release
 on: 
   workflow_dispatch:
   schedule:
-    - cron:  '0 12 * * 4'
+    - cron:  '0 12 * * 1'
 
 env:
   CLUSTER_BASE_NAME: biock8sredis


### PR DESCRIPTION
Because thursday is too late (prone to bit rot), and AnVIL / Bioc meetings are on Tuesdays.