### PR TITLE
Add error logs

### DIFF
--- a/R/depends_apply.R
+++ b/R/depends_apply.R
@@ -177,10 +177,11 @@
         ## If the log "kube_progress" is not configured,
         ## it will just print the message on the screen
         flog.info(
-            "Total: %d, working: %d, failed/finished: %d",
+            "Total: %d, working: %d, failed:%d, success: %d",
             length(number_of_deps),
             length(working),
-            sum(number_of_deps < 0),
+            length(failed),
+            sum(number_of_deps < 0) - length(failed),
             name = "kube_progress"
         )
         failed

--- a/R/kube_install.R
+++ b/R/kube_install.R
@@ -199,6 +199,9 @@ kube_install <-
         length(deps),
         name = "kube_install"
     )
+    
+    error_file <- file.path(logs_path, 'kube_errors.log')
+    flog.appender(appender.tee(error_file), name = 'kube_errors')
 
     progress_file <- file.path(logs_path, 'kube_progress.log')
     flog.appender(appender.tee(progress_file), name = 'kube_progress')
@@ -238,7 +241,15 @@ kube_install <-
             name = "kube_install"
         )
     }
-
+    
+    if (length(iter$this$failed)) {
+        pkgs <- as.list(iter$this$failed)
+        msg <- paste0(names(pkgs), 
+                      " failed for the reason: ",
+                      as.character(pkgs))
+       flog.error(msg, name = "kube_errors") 
+    }
+    
     ## Create PACKAGES, PACKAGES.gz, PACAKGES.rds
     tools::write_PACKAGES(bin_path, addFiles = TRUE, verbose = TRUE)
     flog.info("PACKAGES files created", name = "kube_install")

--- a/tests/testthat/test_depends_apply.R
+++ b/tests/testthat/test_depends_apply.R
@@ -1,5 +1,6 @@
 futile.logger::flog.threshold("FATAL", name = "kube_install")
 futile.logger::flog.threshold("FATAL", name = "kube_progress")
+futile.logger::flog.threshold("FATAL", name = "kube_errors")
 
 test_that("reverse dependences", {
     deps <- list(
@@ -129,3 +130,4 @@ test_that("package iterator", {
 
 futile.logger::flog.threshold("INFO", name = "kube_install")
 futile.logger::flog.threshold("INFO", name = "kube_progress")
+futile.logger::flog.threshold("INFO", name = "kube_errors")

--- a/tests/testthat/test_kube_install.R
+++ b/tests/testthat/test_kube_install.R
@@ -1,5 +1,6 @@
 futile.logger::flog.threshold("FATAL", name = "kube_install")
 futile.logger::flog.threshold("FATAL", name = "kube_progress")
+futile.logger::flog.threshold("FATAL", name = "kube_errors")
 
 test_that("build dummy pkgs", {
     deps <- list(
@@ -83,3 +84,4 @@ test_that("build pkgs", {
 
 futile.logger::flog.threshold("INFO", name = "kube_install")
 futile.logger::flog.threshold("INFO", name = "kube_progress")
+futile.logger::flog.threshold("INFO", name = "kube_errors")


### PR DESCRIPTION
This pull request adds error logs `kube_errors.log` in `logs_path`. The content will look like
```
ERROR [2022-03-02 16:23:17] A failed for the reason: I fail on purpose
ERROR [2022-03-02 16:23:17] C failed for the reason: Unable to build the package due to the dependence failure: A
ERROR [2022-03-02 16:23:17] E failed for the reason: Unable to build the package due to the dependence failure: A
ERROR [2022-03-02 16:23:17] F failed for the reason: Unable to build the package due to the dependence failure: A
```

The pull request also fixes the issue in `kube_progress.log` to allow it to show the number of failed and success packages separately. E.g.
```
INFO [2022-03-02 16:19:32] Total: 7, working: 1, failed:4, success: 0
INFO [2022-03-02 16:19:32] Total: 7, working: 1, failed:4, success: 1
INFO [2022-03-02 16:19:32] Total: 7, working: 0, failed:4, success: 2
INFO [2022-03-02 16:19:32] Total: 7, working: 0, failed:4, success: 3
```