### PR TITLE
Update helm chart to reflect default command

### DIFF
--- a/inst/helm-chart/templates/manager-deployment.yaml
+++ b/inst/helm-chart/templates/manager-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - {{ if .Values.manager.extraCommand -}}
           {{- tpl .Values.manager.extraCommand $ }};
           {{- end -}}
-          Rscript -e 'BiocKubeInstall::kube_run("{{ .Values.biocVersion }}", image_name = "{{ .Values.dockerImageName }}", exclude_pkgs = c("canceR"))'
+          {{ .Values.manager.defaultCommand }}
   restartPolicy: {{ .Values.restartPolicy | quote}}
   volumes:
   - name: nfs-data

--- a/inst/helm-chart/values.yaml
+++ b/inst/helm-chart/values.yaml
@@ -28,6 +28,8 @@ manager:
   image:
     repository: bioconductor/bioc-redis
     tag: manager
+  defaultCommand: |-
+    Rscript -e 'BiocKubeInstall::kube_run("{{ .Values.biocVersion }}", image_name = "{{ .Values.dockerImageName }}", exclude_pkgs = c("canceR"))'
   # Inject an `sh` prequel command to run before `RScript -e BiocKubeInstall::kube_run`
   extraCommand: ""
   resources:
@@ -65,7 +67,7 @@ restartPolicy: OnFailure
 rstudio:
   port: 8787                    # RStudioServer configured to listen here
   protocol: http
-  type: NodePort
+  type: LoadBalancer
 
 # internal redis-specific config
 redis:

--- a/inst/helm-chart/values.yaml
+++ b/inst/helm-chart/values.yaml
@@ -67,7 +67,7 @@ restartPolicy: OnFailure
 rstudio:
   port: 8787                    # RStudioServer configured to listen here
   protocol: http
-  type: LoadBalancer
+  type: NodePort
 
 # internal redis-specific config
 redis:


### PR DESCRIPTION
- RStudio now gets hosted by assigning IP via LoadBalancer